### PR TITLE
New target line functionality

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -10,6 +10,10 @@ Attributes
 
 - *target (property)* sets a value for a straight target line to be drawn on the graph.
 
+- *upperLimit (property)* sets a value for a straight upper limit line to be drawn on the graph.
+
+- *lowerLimit (property)* sets a value for a straight lower limit line to be drawn on the graph.
+
 - *lineColor (property)* sets the color used for line display. Color is supplied as a UIColor object.
 
 - *highlightedColor (property)* sets the color to be used for line display when the view is selected. Color is supplied as a UIColor object.

--- a/README.mdown
+++ b/README.mdown
@@ -8,6 +8,8 @@ Attributes
 
 - *data (property)* sets the datasource for the view. Datasource is provided as a NSArray containing NSNumber objects.
 
+- *target (property)* sets a value for a straight target line to be drawn on the graph.
+
 - *lineColor (property)* sets the color used for line display. Color is supplied as a UIColor object.
 
 - *highlightedColor (property)* sets the color to be used for line display when the view is selected. Color is supplied as a UIColor object.

--- a/README.mdown
+++ b/README.mdown
@@ -6,15 +6,11 @@ CKSparkline is an open source library that provides your application easy access
 Attributes
 ----------
 
-- *data (property)* sets the datasource for the view. Datasource is provided as a NSArray containing NSNumber objects.
-
-- *target (property)* sets a value for a straight target line to be drawn on the graph.
-
-- *upperLimit (property)* sets a value for a straight upper limit line to be drawn on the graph.
-
-- *lowerLimit (property)* sets a value for a straight lower limit line to be drawn on the graph.
+- *data (property)* sets the datasource for the view. Datasource is provided as a NSArray containing 2 objects. The first object is an array of values for plotting. The second object is a number representing the target line.
 
 - *lineColor (property)* sets the color used for line display. Color is supplied as a UIColor object.
+
+- *targetLineColor (property)* sets the color used for the taregt line display. Color is supplied as a UIColor object. Default color is black.
 
 - *highlightedColor (property)* sets the color to be used for line display when the view is selected. Color is supplied as a UIColor object.
 
@@ -25,6 +21,8 @@ Attributes
 - *drawPoints (property)* draws an ellipse at each data point, with the final point drawn in red.
 
 - *drawArea (property)* fills the area below the line.
+
+- *drawTargetDashed (property)* specifies whether target line should be dashed. Defaults to solid.
 
 
 Example Usage

--- a/examples/SparklineViewer/Classes/SparklineViewerViewController.m
+++ b/examples/SparklineViewer/Classes/SparklineViewerViewController.m
@@ -23,7 +23,7 @@
     self.sparkline.drawArea = YES;
 
     // Create an array of data
-    self.sparkline.data = [NSArray arrayWithObjects:
+    NSArray *myArray = [NSArray arrayWithObjects:
                               [NSNumber numberWithFloat:2.0],
                               [NSNumber numberWithFloat:4.5],
                               [NSNumber numberWithFloat:5.2],
@@ -33,7 +33,15 @@
                               [NSNumber numberWithFloat:9.2],
                               nil];
 }
-
+    
+    // Specify target line to be dashed.
+    self.sparkline.drawTargetDashed=YES;
+    
+    //Specify color of target line.
+    self.sparkline.targetlineColor=[UIColor greenColor];
+   
+    //Assign data array and target value to data property.
+    self.sparkline.data=@[myArray, @6];
 
 - (void)dealloc
 {

--- a/src/CKSparkline.h
+++ b/src/CKSparkline.h
@@ -30,6 +30,7 @@ static inline CGPoint calculatePosition(NSArray *data, int index, CKBoundary *bo
     BOOL selected;
 
     UIColor *lineColor;
+    UIColor *targetLineColor;
     CGFloat lineWidth;
     UIColor *highlightedLineColor;
     BOOL drawPoints;
@@ -48,6 +49,10 @@ static inline CGPoint calculatePosition(NSArray *data, int index, CKBoundary *bo
 @property (nonatomic) BOOL drawArea;
 @property (nonatomic, retain) NSArray *data;
 @property (readonly) NSArray *computedData;
+
+//New target line properties.
+@property (nonatomic, retain) UIColor *targetlineColor;
+@property (nonatomic) BOOL drawTargetDashed;
 
 - (void)initializeDefaults;
 - (void)setSelected:(BOOL)isSelected;


### PR DESCRIPTION
As discussed, here is a pull request for the implementation of drawing a target line on a existing graph.

A note on how I implemented it. I started by using a targetLineValue property. Problem with this was that the user would have to set this value before the set the data property of the graph. Having this constraint didn't seem intuitive to me.

So instead now I have modified the code so that the user will send an array of objects to the graph with the first object being the data and the second object a target value. If no target object is provided, the graph draws normally. If a target object is included then a target line will draw.

Check it out and let me know what you think or if you want to see it run a different way.
